### PR TITLE
Add pattern matching to Supervisor program names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-dist
-supermgr.egg-info
+build/
+dist/
+*.egg-info/
 .idea

--- a/supermgr/cli.py
+++ b/supermgr/cli.py
@@ -11,6 +11,7 @@ import os
 import argparse
 import tailer
 import pickle
+import fnmatch
 
 pp = pprint.PrettyPrinter(indent=4)
 
@@ -48,10 +49,11 @@ def display_workers(workers, prgm=None, full=False):
     prgm_not_found = []
     if prgm:
         for p in prgm:
-            if p not in workers:
-                prgm_not_found.append('{e}: no workers found for {p}'.format(
-                    e=color('ERROR', Fore.RED + Style.BRIGHT),
-                    p=color(p, Fore.CYAN + Style.BRIGHT)))
+            for w in workers:
+                if not fnmatch.fnmatch(w, p):
+                    prgm_not_found.append('{e}: no workers found for {p}'.format(
+                        e=color('ERROR', Fore.RED + Style.BRIGHT),
+                        p=color(p, Fore.CYAN + Style.BRIGHT)))
 
     for name, worker in workers.items():
         print(color(name, Fore.CYAN + Style.BRIGHT))

--- a/supermgr/procs.py
+++ b/supermgr/procs.py
@@ -1,4 +1,5 @@
 from collections import defaultdict, OrderedDict
+import fnmatch
 
 from .server import Server
 from .worker import Worker
@@ -22,10 +23,11 @@ def get_workers(group_names=None, filter_state=None):
     for info in data:
         w = Worker(info)
         if group_names:
-            if w.group in group_names:
-                _data = __filter_workers(w, filter_state)
-                if _data:
-                    workers[w.group].update(_data)
+            for group in group_names:
+                if fnmatch.fnmatch(w.group, group):
+                    _data = __filter_workers(w, filter_state)
+                    if _data:
+                        workers[w.group].update(_data)
         else:
             _data = __filter_workers(w, filter_state)
             if _data:


### PR DESCRIPTION
This prototypes the addition of Unix shell-style pattern matching via [`fnmatch`](https://docs.python.org/2/library/fnmatch.html) for Supervisor program names.

For example, this would enable you to interact with `apply`, `apply-post-process`, and `apply-transform-legacy` programs with a single pattern:

```
supermgr --list apply*
```

There are probably some optimizations that could be implemented, but this gets things started.